### PR TITLE
Missing application name workaround

### DIFF
--- a/src/pulseaudio/paclient.go
+++ b/src/pulseaudio/paclient.go
@@ -102,8 +102,13 @@ func (client *PAClient) refreshStreams() error {
 		panic(err)
 	}
 	client.playbackStreams = lo.Map(sinksInputs, func(sinkInput pulseaudio.SinkInput, i int) Stream {
+		var name string
+		name = sinkInput.PropList["application.name"]
+		if len(name) < 1 {
+			name = sinkInput.PropList["media.name"]
+		}
 		return Stream{
-			name:     sinkInput.PropList["application.name"],
+			name:     name,
 			fullName: sinkInput.PropList["module-stream-restore.id"],
 			paStream: sinkInput,
 		}
@@ -114,8 +119,13 @@ func (client *PAClient) refreshStreams() error {
 		panic(err)
 	}
 	client.recordStreams = lo.Map(sourcesOutputs, func(sourceOutput pulseaudio.SourceOutput, i int) Stream {
+		var name string
+		name = sourceOutput.PropList["application.name"]
+		if len(name) < 1 {
+			name = sourceOutput.PropList["media.name"]
+		}
 		return Stream{
-			name:     sourceOutput.PropList["application.name"],
+			name:     name,
 			fullName: sourceOutput.PropList["module-stream-restore.id"],
 			paStream: sourceOutput,
 		}


### PR DESCRIPTION
First off: Big thanks for making this work with pipewire! I had an issue with controlling the stream of 'module-loopback' as it does not provide the `application.name` property. So this very simple hack falls back to `media.name` in such a case.
Maybe this issue deserves a more sophisticated solution, but this works fine for me.